### PR TITLE
Patch to overcome fatal error during finder indexer update

### DIFF
--- a/source/plg_system_t3/t3.php
+++ b/source/plg_system_t3/t3.php
@@ -352,9 +352,11 @@ class plgSystemT3 extends JPlugin
 			if (!$chromed) {
 				$chromed = true;
 				// We don't need chrome multi times
-				$chromePath = T3Path::getPath('html/modules.php');
-				if (file_exists($chromePath)) {
-					include_once $chromePath;
+				if (class_exists('T3Path')) {
+					$chromePath = T3Path::getPath('html/modules.php');
+					if (file_exists($chromePath)) {
+						include_once $chromePath;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
in smart search command line indexing
php /var/www/joomla/cli/finder_indexer.php
I've got
PHP Fatal error:  Class 'T3Path' not found in /var/www/joomla/plugins/system/t3/t3.php on line 355

Thanks for the great job, guys!